### PR TITLE
Use correct namespace everywhere

### DIFF
--- a/Source/ConnectorConfiguration.cs
+++ b/Source/ConnectorConfiguration.cs
@@ -2,10 +2,9 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using RaaLabs.Edge.Modules.Configuration;
-using RaaLabs.Edge.Connectors.Terasaki;
 using System.Diagnostics.CodeAnalysis;
 
-namespace RaaLabs.TimeSeries.Terasaki
+namespace RaaLabs.Edge.Connectors.Terasaki
 {
     /// <summary>
     /// Represents the configuration for <see cref="TcpConnector"/>

--- a/Source/Program.cs
+++ b/Source/Program.cs
@@ -1,14 +1,12 @@
 // Copyright (c) RaaLabs. All rights reserved.
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
-using RaaLabs.Edge;
 using RaaLabs.Edge.Modules.EventHandling;
 using RaaLabs.Edge.Modules.EdgeHub;
 using RaaLabs.Edge.Modules.Configuration;
-using RaaLabs.Edge.Connectors.Terasaki;
 using System.Diagnostics.CodeAnalysis;
 
-namespace RaaLabs.TimeSeries.Terasaki
+namespace RaaLabs.Edge.Connectors.Terasaki
 {
     [ExcludeFromCodeCoverage]
     static class Program

--- a/Source/TcpConnector.cs
+++ b/Source/TcpConnector.cs
@@ -2,7 +2,6 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using RaaLabs.Edge.Modules.EventHandling;
-using RaaLabs.TimeSeries.Terasaki;
 using Serilog;
 using System;
 using System.IO;

--- a/Source/events/TcpLineReceived.cs
+++ b/Source/events/TcpLineReceived.cs
@@ -1,3 +1,6 @@
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using RaaLabs.Edge.Modules.EventHandling;
 
 namespace RaaLabs.Edge.Connectors.Terasaki.Events

--- a/Source/events/TerasakiDatapointOutput.cs
+++ b/Source/events/TerasakiDatapointOutput.cs
@@ -1,3 +1,6 @@
+// Copyright (c) RaaLabs. All rights reserved.
+// Licensed under the MIT license. See LICENSE file in the project root for full license information.
+
 using RaaLabs.Edge.Modules.EdgeHub;
 
 


### PR DESCRIPTION
## Summary

Initially thought this module still makes use of the old Timeseries nuget package, but it was just the namespaces that were mixed up. Corrected to use the same everywhere.


### Changed
- use `RaaLabs.Edge.Connectors.Terasaki` namespace everywhere
- added license info on top of file where missing